### PR TITLE
feat: seperate exclude function

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,15 +67,14 @@ export class AppComponent {
 
 ### Options
 
-| Property name | Type | Default | Description |
-| ------------- | ---- | ------- | ----------- |
+| Property name | Type | Default | Description                                                                                                                                                                                                                                       |
+| ------------- | ---- | ------- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `attachOutsideOnClick` | boolean | `false` | By default, the outside click event handler is automatically attached. Explicitely setting this to `true` sets the handler after the element is clicked. The outside click event handler will then be removed after a click outside has occurred. |
-| `clickOutsideEnabled` | boolean | `true` | Enables directive. |
-| `clickOutsideEvents` | string | `'click'` | A comma-separated list of events to cause the trigger. For example, for additional mobile support: `[clickOutsideEvents]="'click,touchstart'"`. |
-| `delayClickOutsideInit` | boolean | `false` | Delays the initialization of the click outside handler. This may help for items that are conditionally shown ([see issue #13](https://github.com/arkon/ng-click-outside/issues/13)). |
-| `emitOnBlur` | boolean | `false` | If enabled, emits an event when user clicks outside of applications' window while it's visible. Especially useful if page contains iframes. |
-| `exclude` | string | | A comma-separated string of DOM element queries to exclude when clicking outside of the element. For example: `[exclude]="'button,.btn-primary'"`. |
-| `excludeBeforeClick` | boolean | `false` | By default, `clickOutside` registers excluded DOM elements on init. This property refreshes the list before the `clickOutside` event is triggered. This is useful for ensuring that excluded elements added to the DOM after init are excluded (e.g. ng2-bootstrap popover: this allows for clicking inside the `.popover-content` area if specified in `exclude`). |
+| `clickOutsideEnabled` | boolean | `true` | Enables directive.                                                                                                                                                                                                                                |
+| `clickOutsideEvents` | string | `'click'` | A comma-separated list of events to cause the trigger. For example, for additional mobile support: `[clickOutsideEvents]="'click,touchstart'"`.                                                                                                   |
+| `delayClickOutsideInit` | boolean | `false` | Delays the initialization of the click outside handler. This may help for items that are conditionally shown ([see issue #13](https://github.com/arkon/ng-click-outside/issues/13)).                                                              |
+| `emitOnBlur` | boolean | `false` | If enabled, emits an event when user clicks outside of applications' window while it's visible. Especially useful if page contains iframes.                                                                                                       |
+| `clickOutsideExclude` | string | | A comma-separated string of DOM element queries to exclude when clicking outside of the element. (Import NgClickOutsideExcludeDirective) For example: `[clickOutsideExclude]="'button,.btn-primary'"`.                                                                                      |
 
 ## Migration from ng-click-outside
 

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -3,6 +3,7 @@
   (clickOutside)="onClickedOutside($event)"
   [attachOutsideOnClick]="attachOutsideOnClick"
   [clickOutsideEnabled]="enabled"
+  [clickOutsideExclude]="'.foo'"
   [emitOnBlur]="true">
   <p>Clicked inside: {{countInside}}</p>
   <p>Clicked outside: {{countOutside}}</p>
@@ -17,3 +18,4 @@
     <span>Enabled</span>
   </label>
 </div>
+<div class="foo" [style.height.px]="200"></div>

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { AppComponent } from './app.component';
-import {NgClickOutsideDirective} from "ng-click-outside2";
+import {NgClickOutsideDirective, NgClickOutsideExcludeDirective} from "ng-click-outside2";
 
 @NgModule({
   declarations: [
@@ -10,7 +10,8 @@ import {NgClickOutsideDirective} from "ng-click-outside2";
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'serverApp' }),
-    NgClickOutsideDirective
+    NgClickOutsideDirective,
+    NgClickOutsideExcludeDirective
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/projects/ng-click-outside2/src/lib/ng-click-outside-exclude.directive.spec.ts
+++ b/projects/ng-click-outside2/src/lib/ng-click-outside-exclude.directive.spec.ts
@@ -1,29 +1,34 @@
+import { NgClickOutsideExcludeDirective } from './ng-click-outside-exclude.directive';
+import {Component, ViewChild} from "@angular/core";
 import {NgClickOutsideDirective} from "./ng-click-outside.directive";
 import {ComponentFixture, TestBed} from "@angular/core/testing";
-import {Component, ViewChild} from "@angular/core";
-import {By} from "@angular/platform-browser";
 import {DOCUMENT} from "@angular/common";
+import {By} from "@angular/platform-browser";
+
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'test-click',
   standalone: true,
-  imports: [NgClickOutsideDirective],
+  imports: [NgClickOutsideDirective, NgClickOutsideExcludeDirective],
   template: `
     <button id="b-1" (click)="clickButton1 = clickButton1 + 1"></button>
-    <button id="b-2" (clickOutside)="clickOutsideButton2 = clickOutsideButton2 + 1"
+    <button id="b-2" (clickOutside)="clickOutsideButton2 = clickOutsideButton2 + 1" [clickOutsideExclude]="'.no-outside-click'"
             (click)="clickButton2 = clickButton2 + 1"   [clickOutsideEnabled]="enabled"
-    ></button>`
+    ></button>
+    <button id="b-3" (click)="clickButton3 = clickButton3 + 1" class="no-outside-click"></button>
+  `
 })
 class TestClickOutsideComponent {
   @ViewChild(NgClickOutsideDirective) ngClickOutsideDirective?: NgClickOutsideDirective
   clickOutsideButton2 = 0;
   clickButton1 = 0;
   clickButton2 = 0;
+  clickButton3 = 0;
   enabled = true
 }
 
-describe('NgClickOutsideDirective', () => {
+describe('NgClickOutsideExcludeDirective', () => {
   let component: TestClickOutsideComponent;
   let fixture: ComponentFixture<TestClickOutsideComponent>;
 
@@ -38,23 +43,16 @@ describe('NgClickOutsideDirective', () => {
     fixture.detectChanges();
   })
 
-  it('should click outside', () => {
-    const button1 = fixture.debugElement.query(By.css('#b-1'));
-    button1.nativeElement.click();
-    expect(component.clickButton1).toBe(1);
+
+  it('should excludeDirective should be defined when attribute exclude exists ', () => {
+    expect(component.ngClickOutsideDirective!.excludeDirective).toBeDefined();
+  });
+
+  it('should not count click of Button 3 as it is excluded', () => {
+    const button3 = fixture.debugElement.query(By.css('#b-3'));
+    button3.nativeElement.click();
+    expect(component.clickButton3).toBe(1);
     expect(component.clickButton2).toBe(0);
-    expect(component.clickOutsideButton2).toBe(1);
-  });
+    expect(component.clickOutsideButton2).toBe(0);  });
 
-  it('should click on button', () => {
-    const button2 = fixture.debugElement.query(By.css('#b-2'));
-    button2.nativeElement.click();
-    expect(component.clickButton1).toBe(0);
-    expect(component.clickButton2).toBe(1);
-    expect(component.clickOutsideButton2).toBe(0);
-  });
-
-  it('should excludeDirective not exist if we do not define exclude ', () => {
-    expect(component.ngClickOutsideDirective!.excludeDirective).toBeNull();
-  });
 });

--- a/projects/ng-click-outside2/src/lib/ng-click-outside-exclude.directive.ts
+++ b/projects/ng-click-outside2/src/lib/ng-click-outside-exclude.directive.ts
@@ -1,0 +1,52 @@
+import {Directive, inject, Inject, Input} from '@angular/core';
+import {DOCUMENT} from "@angular/common";
+
+/**
+ * Optimization for Treeshaking: https://angular.io/guide/lightweight-injection-tokens
+ */
+export abstract class NgClickOutsideExcludeToken {
+  abstract isExclude(target: any): boolean;
+}
+
+@Directive({
+  selector: '[clickOutsideExclude]',
+  standalone: true,
+  providers: [
+    {provide: NgClickOutsideExcludeToken, useExisting: NgClickOutsideExcludeDirective}
+  ]
+})
+export class NgClickOutsideExcludeDirective extends NgClickOutsideExcludeToken {
+
+  /**
+   * A comma-separated string of DOM element queries to exclude when clicking outside of the element.
+   * For example: `[exclude]="'button,.btn-primary'"`.
+   */
+  @Input() clickOutsideExclude = '';
+
+  private document: Document = inject(DOCUMENT);
+
+  public excludeCheck(): HTMLElement[] {
+    if (this.clickOutsideExclude) {
+      try {
+        const nodes = Array.from(this.document.querySelectorAll(this.clickOutsideExclude)) as Array<HTMLElement>;
+        if (nodes) {
+          return nodes;
+        }
+      } catch (err) {
+        console.error('[ng-click-outside] Check your exclude selector syntax.', err);
+      }
+    }
+    return [];
+  }
+
+  public isExclude(target: any): boolean {
+    const nodesExcluded = this.excludeCheck();
+    for (let excludedNode of nodesExcluded) {
+      if (excludedNode.contains(target)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/projects/ng-click-outside2/src/public-api.ts
+++ b/projects/ng-click-outside2/src/public-api.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './lib/ng-click-outside.directive';
+export * from './lib/ng-click-outside-exclude.directive';


### PR DESCRIPTION
seperate exclude function into own directive to make ng-click-outisde better treeshakable when exclude is not needed. This comes from the idea that most users might only need the outside click but not the other "special" functions which are provided

Pro
- smaller bundle by only shipping what is needed

Con
- additional import needed  

Other potential candidates to split out are attributes / functionality:
- emitOnBlur
- attachOutsideOnClick
- delayClickOutsideInit

Feedback would be very welcome, espacally if the small bundle change is worth the effort