### PR TITLE
fix: prevent click outside event on disconnected Elements

### DIFF
--- a/projects/ng-click-outside2/src/lib/ng-click-outside.directive.ts
+++ b/projects/ng-click-outside2/src/lib/ng-click-outside.directive.ts
@@ -99,6 +99,10 @@ export class NgClickOutsideDirective implements OnDestroy {
       return;
     }
 
+    if (ev.target instanceof HTMLElement && !ev.target.isConnected) {
+      return;
+    }
+
     if (!this._el.nativeElement.contains(ev.target) && !this.excludeDirective?.isExclude(ev.target)) {
       this._emit(ev);
     }


### PR DESCRIPTION
Implements: 88
BREAKING-CHANGE: outside click will not fire for disconnected elements