### PR TITLE
fix: prevent click outside event on elements which got removed

### DIFF
--- a/projects/ng-click-outside2/src/lib/ng-click-outside-delay-outside.directive.ts
+++ b/projects/ng-click-outside2/src/lib/ng-click-outside-delay-outside.directive.ts
@@ -19,9 +19,9 @@ export class NgClickOutsideDelayOutsideDirective extends NgClickOutsideDirective
 
   protected override _initOnClickBody() {
     if (this.delayClickOutsideInit()) {
-      setTimeout(this._initClickOutsideListener.bind(this));
+      setTimeout(super.initListener.bind(this));
     } else {
-      this._initClickOutsideListener();
+      super.initListener();
     }
   }
 }

--- a/projects/ng-click-outside2/tsconfig.lib.json
+++ b/projects/ng-click-outside2/tsconfig.lib.json
@@ -9,7 +9,7 @@
     "types": [],
     "lib": [
       "dom",
-      "es2018"
+      "esnext"
     ]
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,10 +20,10 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "ES2022",
+    "target": "esnext",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "esnext",
       "dom"
     ],
     "useDefineForClassFields": false


### PR DESCRIPTION
Implements: 88
BREAKING-CHANGE: outside click will not fire for removed sub elements